### PR TITLE
Support ruby's master branch instead of trunk

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -5,7 +5,7 @@ class ReportsController < ApplicationController
     @use_opacity = false
     @reports = Report.order('datetime DESC').limit(300).includes(:server)
 
-    str = params[:branch].to_s[/\A(?:trunk|[\d.]+)\z/]
+    str = params[:branch].to_s[/\A(?:trunk|master|[\d.]+)\z/]
     @reports = @reports.where(branch: str) if str
 
     str = params[:result].to_s[/\A(?:success|failure)\z/]

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -263,7 +263,7 @@ class Report < ApplicationRecord
     Net::HTTP.start(uri.host, uri.port, open_timeout: 10, read_timeout: 10) do |h|
       puts "getting #{uri.host}#{path} ..."
       h.get(path).body.scan(/(?:<Prefix>[\w\-]+\/|<Name>|(?:href|HREF)=")((?:cross)?ruby-[^"\/]+)/) do |depsuffixed_name,_|
-        next if /\Acrossruby-trunk-[a-z0-9]+|\Aruby-(?:trunk|[1-9])/ !~ depsuffixed_name
+        next if /\Acrossruby-(?:trunk|master)-[a-z0-9]+|\Aruby-(?:trunk|master|[1-9])/ !~ depsuffixed_name
 
         begin # LTSV
           path = File.join(basepath, depsuffixed_name, 'recent.ltsv')

--- a/lib/chkbuild-ruby-info.rb
+++ b/lib/chkbuild-ruby-info.rb
@@ -346,8 +346,8 @@ class ChkBuildRubyInfo
   def extract_branch
     h = { 'type' => 'branch' }
     case @last_hash["ruby_branch"]
-    when /\Atrunk\z/
-      h['branch'] = 'trunk'
+    when /\A(?:trunk|master)\z/
+      h['branch'] = 'trunk' # or should it be 'master'?
     when %r{\Abranches/ruby_(\d+)_(\d+)_(\d+)\z}
       h['branch'] = "#{$1}.#{$2}.#{$3}"
     when %r{\Abranches/ruby_(\d+)_(\d+)\z}


### PR DESCRIPTION
Now chkbuild saves the result in "ruby-master" directory instead of
"ruby-trunk".  rubyci needs to support the new branch name.