### PR TITLE
Hide trunk reports instead of the tentative hack

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -32,6 +32,10 @@ class ReportsController < ApplicationController
         where("reports.datetime > (now() - interval '14 days')").
         where('reports.id IN (SELECT MAX(R.id) FROM reports R GROUP BY R.server_id, R.branch, R.option)').all
       @reports = @reports.to_a.delete_if{|report| report.server.nil? }
+
+      # Just remove reports for the old "trunk" branch
+      @reports = @reports.delete_if{|report| report.branch == "trunk" }
+
       render 'index'
     end
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -32,23 +32,6 @@ class ReportsController < ApplicationController
         where("reports.datetime > (now() - interval '14 days')").
         where('reports.id IN (SELECT MAX(R.id) FROM reports R GROUP BY R.server_id, R.branch, R.option)').all
       @reports = @reports.to_a.delete_if{|report| report.server.nil? }
-
-      # A tentative hack for placing master-branch reports into the corresponding trunk ones
-      report_index = {}
-      @reports.each_with_index do |report, i|
-        report_index[[report.server.name, report.branch]] = i
-      end
-      @reports.dup.each_with_index do |report, j|
-        if report.branch == "master"
-          i = report_index[[report.server.name, "trunk"]]
-          if i
-            @reports[i] = report
-            @reports[j] = nil
-          end
-        end
-      end
-      @reports = @reports.compact
-
       render 'index'
     end
   end

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -45,7 +45,7 @@
             revision_link = link_to revision, report.revisionuri
           end
         %>
-        <tr class="<%= 'branch-separator' if curbr != (report.branch == "master" ? "trunk" : report.branch) %>"<%=raw style%>>
+        <tr class="<%= 'branch-separator' if curbr != report.branch %>"<%=raw style%>>
           <td class="server"><%= report.server.name %></td>
           <td class="datetime"><%= link_to report.sjstdt, report.loguri, title: report.jstdt %></td>
           <td class="branch"><%= link_to report.branch, report.recenturi %></td>
@@ -65,7 +65,7 @@
           <% end %>
           <td class="diff"><div><%= link_to report.diffstat, diffuri, title: report.diffstat %></div></td>
         </tr>
-        <% curbr = (report.branch == "master" ? "trunk" : report.branch) %>
+        <% curbr = report.branch %>
       <% end %>
     </tbody>
   </table>
@@ -105,7 +105,7 @@
           diffuri = URI(report.diffuri)
           diffuri = CGI.unescape(log_path(diffuri.host + diffuri.path))
         %>
-        <tr class="<%= 'branch-separator' if curbr != (report.branch == "master" ? "trunk" : report.branch) %>"<%=raw style%>>
+        <tr class="<%= 'branch-separator' if curbr != report.branch %>"<%=raw style%>>
           <td class="server"><%= report.server.name %></td>
           <td class="datetime"><%= link_to report.sjstdt, report.loguri, title: report.jstdt %></td>
           <td class="branch"><%= link_to report.branch, report.recenturi %></td>
@@ -125,7 +125,7 @@
           <% end %>
           <td class="diff"><div><%= link_to report.diffstat, diffuri, title: report.diffstat %></div></td>
         </tr>
-        <% curbr = report.branch == "master" ? "trunk" : report.branch %>
+        <% curbr = report.branch %>
       <% end %>
     </tbody>
   </table>


### PR DESCRIPTION
#106 introduced a tentative hack to reorder reports to show "trunk" branches and "master" branches in the same rank.

Almost all CI environments have switched to "master" branch.  (AIX still shows "trunk" but it has already switched [according to the admin](https://twitter.com/ReiOdaira/status/1133018784921509888).)

This PR reverts the hack and just hide "trunk" branches in the top page.