### PR TITLE
Remove OSUOSL from the supporter list

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,6 @@
         </p>
         <ul>
           <li><%= link_to "Amazon Web Services, Inc.", "https://aws.amazon.com/" %>,</li>
-          <li><%= link_to "Datacenter OSUOSL", "http://osuosl.org/" %>,</li>
           <li><%= link_to "Fujitsu Limited", "https://www.fujitsu.com/" %>,</li>
           <li><%= link_to "Heroku, Inc.", "http://www.heroku.com/" %></li>
         </ul>


### PR DESCRIPTION
They had provided an AIX machine but it does not work for a year.
Only Odaira-san can log in to the machine, and will deal with the issue,
but it won't be possible so soon, so temporarily remove it from the
supporter list.