### PR TITLE
Avoid wrong prefix matching

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -221,7 +221,7 @@ class Report < ApplicationRecord
     bucket = s3.bucket('rubyci')
     objects = bucket.objects({
       delimiter: 'o',
-      prefix: prefix,
+      prefix: prefix + "/",
     })
     count = 0
     objects.each do |object|


### PR DESCRIPTION
For example, server id "arch" must not match a S3 file named
"archlinux/ruby-master/recent.ltsv".