### PR TITLE
Use delimiter "log" instead of "o"

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -220,8 +220,8 @@ class Report < ApplicationRecord
     return unless %r<https?://rubyci.s3.amazonaws.com/(?<prefix>[^/]+)> =~ server.uri
     bucket = s3.bucket('rubyci')
     objects = bucket.objects({
-      delimiter: 'o',
-      prefix: prefix + "/" + (prefix == "crossruby" ? "cross" : ""),
+      delimiter: 'log',
+      prefix: prefix + "/",
     })
     count = 0
     objects.each do |object|


### PR DESCRIPTION
I'm unsure why "o" is selected. Anyway, it ignores the result whose arch
name includes "o" (such as "powerpc").

Related to #254 254