### PR TITLE
Hide normal builds of servers reporting crossruby

### DIFF
--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -18,13 +18,13 @@
 
     <tbody>
       <% curbr = nil; now = Time.now.to_i %>
-      <% @cross_reports = []%>
-      <% @reports.each do |report| %>
+      <% @cross_reports, reports = @reports.partition {|report| report.depsuffixed_name.start_with?('cross') } %>
+      <% cross_server_ids = @cross_reports.map(&:server_id).uniq %>
+      <% reports.each do |report| %>
         <%
-          if report.depsuffixed_name.start_with?('cross')
-            @cross_reports << report
-            next
-          end
+          # A server reporting crossruby builds sometimes runs normal builds
+          # by mistake; hide its normal reports while crossruby ones exist.
+          next if cross_server_ids.include?(report.server_id)
           d = now - report.datetime.to_i
           style = nil
           if @use_opacity && d > 10000


### PR DESCRIPTION
The crossruby host accidentally ran normal `master` and 4.0-3.3 builds, so its logs appear in both the normal table and the crossruby table on rubyci.org. The reports view now skips non-cross reports from any server that currently has crossruby reports, so only the crossruby table shows that host. Other servers are unaffected, and if the accidental runs stop the filter naturally disengages once the crossruby reports age out.

Generated with [Claude Code](https://claude.com/claude-code)
