### PR TITLE
Replace Bootstrap 2 label classes with Bootstrap 5 badges

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,10 +37,10 @@
 
         <div class="alert alert-info">
           <div>
-            F: <span class="label label-important">failure</span>
-            E: <span class="label label-important">error</span>
-            S: <span class="label label-info">skip</span>
-            failed: <span class="label label-important">critical failures</span>
+            F: <span class="badge text-bg-danger">failure</span>
+            E: <span class="badge text-bg-danger">error</span>
+            S: <span class="badge text-bg-info">skip</span>
+            failed: <span class="badge text-bg-danger">critical failures</span>
           </div>
           <div>
             see also <a href="https://rubyci.org/coverage">Code coverage report</a>,


### PR DESCRIPTION
The legend in the layout still used `label label-important` and `label label-info`, which do not exist in Bootstrap 5.2.3, so the badges rendered as plain text. This replaces them with `badge text-bg-danger` and `badge text-bg-info`. Verified the rendered legend locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
