### PR TITLE
Point build log links at logs.rubyci.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .bundle
-db/*.sqlite3
+db/*.sqlite3*
 log/*.log
 tmp/
 .DS_Store

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -155,15 +155,15 @@ class Report < ApplicationRecord
   end
 
   def loguri
-    server.uri.chomp('/') + datetime.strftime("/#{depsuffixed_name}/log/%Y%m%dT%H%M%SZ.log.html.gz")
+    server.log_base_uri + datetime.strftime("/#{depsuffixed_name}/log/%Y%m%dT%H%M%SZ.log.html.gz")
   end
 
   def diffuri
-    server.uri.chomp('/') + datetime.strftime("/#{depsuffixed_name}/log/%Y%m%dT%H%M%SZ.diff.html.gz")
+    server.log_base_uri + datetime.strftime("/#{depsuffixed_name}/log/%Y%m%dT%H%M%SZ.diff.html.gz")
   end
 
   def failuri
-    meta&.[]('compressed_failhtml_relpath') ? "#{server.uri.chomp('/')}/#{depsuffixed_name}/#{meta['compressed_failhtml_relpath']}" : nil
+    meta&.[]('compressed_failhtml_relpath') ? "#{server.log_base_uri}/#{depsuffixed_name}/#{meta['compressed_failhtml_relpath']}" : nil
   end
 
   def recenturi

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -5,6 +5,9 @@ class Server < ApplicationRecord
 
   RUBYCI_S3_HOST = 'rubyci.s3.amazonaws.com'
   RUBYCI_S3_URI = %r{\Ahttps?://#{Regexp.escape(RUBYCI_S3_HOST)}/}
+  # Fastly in front of the same bucket. Object keys are unchanged, so only the
+  # host is swapped.
+  RUBYCI_LOGS_URL = 'https://logs.rubyci.org'
 
   # Most rows still carry the http:// form these URIs were first registered
   # with, so both schemes have to match. Keep the Ruby and SQL forms together
@@ -18,7 +21,13 @@ class Server < ApplicationRecord
     RUBYCI_S3_URI.match?(uri.to_s)
   end
 
+  # Base for the log links shown to users. Bucket-backed servers go through the
+  # CDN; every other server keeps the URI it was registered with.
+  def log_base_uri
+    uri.sub(RUBYCI_S3_URI, "#{RUBYCI_LOGS_URL}/").chomp('/')
+  end
+
   def recent_uri(branch)
-    "#{uri.chomp('/')}/ruby-#{branch}/recent.html"
+    "#{log_base_uri}/ruby-#{branch}/recent.html"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,8 @@ Rails.application.routes.draw do
     end
   end
 
-  get "/coverage" => redirect("https://rubyci.s3.amazonaws.com/coverage-latest-html/index.html")
-  get "/doxygen" => redirect("https://rubyci.s3.amazonaws.com/doxygen-latest-html/index.html")
+  get "/coverage" => redirect("#{Server::RUBYCI_LOGS_URL}/coverage-latest-html/index.html")
+  get "/doxygen" => redirect("#{Server::RUBYCI_LOGS_URL}/doxygen-latest-html/index.html")
 
   #resources :logs, only: [:show], constraints: {id: /.*/}
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -63,6 +63,18 @@ class ReportTest < ActiveSupport::TestCase
     assert_equal SHA, report.sha1
   end
 
+  test "log links go through the CDN" do
+    report = build_report(
+      server: create_server("cdn-links"),
+      datetime: Time.utc(2026, 1, 21, 18, 30, 3),
+      ltsv: "depsuffixed_name:ruby-master\tcompressed_failhtml_relpath:log/20260121T183003Z.fail.html.gz",
+    )
+    assert_equal "https://logs.rubyci.org/cdn-links/ruby-master/log/20260121T183003Z.log.html.gz", report.loguri
+    assert_equal "https://logs.rubyci.org/cdn-links/ruby-master/log/20260121T183003Z.diff.html.gz", report.diffuri
+    assert_equal "https://logs.rubyci.org/cdn-links/ruby-master/log/20260121T183003Z.fail.html.gz", report.failuri
+    assert_equal "https://logs.rubyci.org/cdn-links/ruby-master/recent.html", report.recenturi
+  end
+
   test "extract_full_sha" do
     assert_equal SHA, Report.extract_full_sha("https://github.com/ruby/ruby:#{SHA}")
     assert_equal SHA, Report.extract_full_sha(%["https\\x3A//github.com/ruby/ruby":#{SHA}])

--- a/test/models/server_test.rb
+++ b/test/models/server_test.rb
@@ -18,6 +18,20 @@ class ServerTest < ActiveSupport::TestCase
     assert_not create_server("http://ci.rvm.jp/chkbuild/logs/").rubyci_s3?
   end
 
+  test "log_base_uri points bucket-backed servers at the CDN" do
+    assert_equal "https://logs.rubyci.org/ubuntu", create_server("https://rubyci.s3.amazonaws.com/ubuntu/").log_base_uri
+    assert_equal "https://logs.rubyci.org/rhel9", create_server("http://rubyci.s3.amazonaws.com/rhel9").log_base_uri
+  end
+
+  test "log_base_uri keeps other servers as registered" do
+    assert_equal "http://ci.rvm.jp/chkbuild/logs", create_server("http://ci.rvm.jp/chkbuild/logs/").log_base_uri
+  end
+
+  test "recent_uri uses the CDN host" do
+    server = create_server("https://rubyci.s3.amazonaws.com/debian/")
+    assert_equal "https://logs.rubyci.org/debian/ruby-master/recent.html", server.recent_uri("master")
+  end
+
   test "rubyci_s3 scope selects the same servers as rubyci_s3?" do
     servers = [
       create_server("https://rubyci.s3.amazonaws.com/scope-https/"),


### PR DESCRIPTION
Build log links were generated from the public `rubyci` S3 bucket. A Fastly service now fronts the same bucket at `logs.rubyci.org`, so pointing links there cuts S3 GET and egress cost and serves repeat access during triage from the edge.

`Server#log_base_uri` swaps the host for servers registered under the bucket and leaves every other server on its registered URI, so `loguri`, `diffuri`, `failuri` and `recenturi` all follow. Object keys are unchanged, and the `/coverage` and `/doxygen` redirects move too.

The listing and fetch paths still talk to S3 directly. `failtxt_uri` and `difftxt_uri` stay on S3 as well, since they only feed `LogExcerpt.capture`, which can run before the object is uploaded, and a 404 cached under the one year TTL on `/log/` keys would outlive any chance to recover it.

Direct S3 URLs keep working, so this is reversible. The second commit widens the `.gitignore` pattern so the per-worker databases `rake test` writes are ignored.
